### PR TITLE
[MSBuild] Add missing NuGet package metadata items

### DIFF
--- a/src/NuGet.Packages.Targets/NuGet.Packaging.targets
+++ b/src/NuGet.Packages.Targets/NuGet.Packaging.targets
@@ -108,10 +108,11 @@
     <NuGetLanguage>$(Language)</NuGetLanguage>
     <NuGetProjectUrl>$(ProjectUrl)</NuGetProjectUrl>
     <NuGetIconUrl>$(IconUrl)</NuGetIconUrl>
+    <NuGetLicenseUrl>$(LicenseUrl)</NuGetLicenseUrl>
     <NuGetCopyright>$(Copyright)</NuGetCopyright>
     <NuGetRequireLicenseAcceptance>$(RequireLicenseAcceptance)</NuGetRequireLicenseAcceptance>
     <NuGetTags>$(Tags)</NuGetTags>
-    <NuGetVersion>$(Version)</NuGetVersion>
+    <NuGetDevelopmentDependency>$(DevelopmentDependency)</NuGetDevelopmentDependency>
   </PropertyGroup>
 
   <Import Project="$(NuGetPackagingPath)\NuGet.Packaging.Common.targets"


### PR DESCRIPTION
License url and development dependency information was not being
passed when generating the .nuspec file for a .nuproj project. Also the package version was being passed twice.