### PR TITLE
[MSBuild] Allow package reference to not specify target framework

### DIFF
--- a/src/NuGet.Packaging.Tasks.Tests/Scenarios/BuildNuProj_PackageReferenceNoTargetFramework/BuildNuProj_PackageReferenceNoTargetFramework.sln
+++ b/src/NuGet.Packaging.Tasks.Tests/Scenarios/BuildNuProj_PackageReferenceNoTargetFramework/BuildNuProj_PackageReferenceNoTargetFramework.sln
@@ -1,0 +1,17 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{5DD5E4FA-CB73-4610-85AB-557B54E96AA9}") = "Package", "Package.nuproj", "{0EAE2A5B-F205-4927-9DE6-4CCD8F44EDAA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0EAE2A5B-F205-4927-9DE6-4CCD8F44EDAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0EAE2A5B-F205-4927-9DE6-4CCD8F44EDAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0EAE2A5B-F205-4927-9DE6-4CCD8F44EDAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0EAE2A5B-F205-4927-9DE6-4CCD8F44EDAA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/NuGet.Packaging.Tasks.Tests/Scenarios/BuildNuProj_PackageReferenceNoTargetFramework/Package.nuproj
+++ b/src/NuGet.Packaging.Tasks.Tests/Scenarios/BuildNuProj_PackageReferenceNoTargetFramework/Package.nuproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|AnyCPU">
+      <Configuration>Debug</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|AnyCPU">
+      <Configuration>Release</Configuration>
+      <Platform>AnyCPU</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectGuid>0EAE2A5B-F205-4927-9DE6-4CCD8F44EDAA</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NuGetPackagingPath Condition=" '$(NuGetPackagingPath)' == '' ">$(LocalAppData)\CustomProjectSystems\NuGet.Packaging\</NuGetPackagingPath>
+  </PropertyGroup>
+  <Import Project="$(NuGetPackagingPath)\NuGet.Packaging.props" Condition="Exists('$(NuGetPackagingPath)\NuGet.Packaging.props')" />
+  <PropertyGroup Label="Configuration">
+    <Id>NuGetPackage</Id>
+    <Version>1.0.0</Version>
+    <Title>NuGetPackage</Title>
+    <Authors>author</Authors>
+    <Owners>owner</Owners>
+    <Summary>Summary</Summary>
+    <Description>Description</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>8.0.3</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$(NuGetPackagingPath)\NuGet.Packaging.targets" />
+</Project>

--- a/src/NuGet.Packaging.Tasks/GenerateNuSpec.cs
+++ b/src/NuGet.Packaging.Tasks/GenerateNuSpec.cs
@@ -439,7 +439,7 @@ namespace NuGet.Packaging.Tasks
                     group dependency by dependency.TargetFramework into dependenciesByFramework
                     select new PackageDependencyGroup
                     (
-                        NuGetFramework.Parse(dependenciesByFramework.Key.GetShortFrameworkName()),
+                        NuGetFramework.Parse(dependenciesByFramework.Key.GetShortFrameworkName() ?? "any"),
                         (from dependency in dependenciesByFramework
                          where dependency.Id != "_._"
                          group dependency by dependency.Id into dependenciesById


### PR DESCRIPTION
Previously a PackageReference in a .nuproj project had to specify
a target framework. So to create a metadata package each package
dependency represented by the PackageReference item in the project
had to specify a target framework of "any". Now if the target
framework is not specified then "any" is assumed. When "any" is used
as a target framework the dependency is added to the .nuspec without
any associated target framework:

    <dependencies>
      <dependency id="Newtonsoft.Json" version="9.0.1" />
    </dependencies>